### PR TITLE
Reorder pretty report contributors after activity; add section order tests

### DIFF
--- a/__tests__/pretty.test.ts
+++ b/__tests__/pretty.test.ts
@@ -4,38 +4,62 @@ import { renderPrettyReport } from '../src/render/pretty.ts'
 import type { AnalysisReport } from '../src/analyze/types.ts'
 import { REPORT_SCHEMA_VERSION } from '../src/analyze/types.ts'
 
+function stripAnsi (s: string): string {
+  return s.replace(/\u001b\[[0-9;]*m/g, '')
+}
+
+/** Stable substrings from `horizontalRule` titles in `renderPrettyReport` (order matters). */
+function assertPrettySectionMarkerOrder (out: string, markers: readonly string[]): void {
+  const plain = stripAnsi(out)
+  const indices = markers.map((m, i) => {
+    const idx = plain.indexOf(m)
+    assert.ok(idx >= 0, `expected pretty output to contain section marker[${String(i)}]: ${JSON.stringify(m)}`)
+    return idx
+  })
+  for (let i = 1; i < indices.length; i++) {
+    assert.ok(
+      indices[i]! > indices[i - 1]!,
+      `section marker[${String(i)}] (${JSON.stringify(markers[i])}) should appear after marker[${String(i - 1)}] (${JSON.stringify(markers[i - 1])})`
+    )
+  }
+}
+
+const basePrettyFixture = (): Omit<AnalysisReport, 'insights'> => ({
+  schemaVersion: REPORT_SCHEMA_VERSION,
+  generatedAt: '2026-04-15T00:00:00.000Z',
+  repository: {
+    path: '/tmp/repo',
+    topLevel: '/tmp/repo',
+    head: 'deadbeef',
+  },
+  churn: { window: '1 year ago', topFiles: [{ path: 'src/app.ts', touches: 42 }] },
+  contributors: {
+    allTime: [{ name: 'Ada', commits: 10 }],
+    lastYear: [{ name: 'Ada', commits: 10 }],
+    lastSixMonths: [{ name: 'Ada', commits: 4 }],
+  },
+  bugHotspots: { pattern: 'fix|bug|broken', topFiles: [{ path: 'src/app.ts', touches: 3 }] },
+  activityByMonth: [
+    { month: '2026-01', commits: 2 },
+    { month: '2026-02', commits: 6 },
+    { month: '2026-03', commits: 4 },
+  ],
+  firefighting: {
+    window: '1 year ago',
+    keywordPattern: 'revert|hotfix|emergency|rollback',
+    matches: [{ hash: 'abc1234', subject: 'hotfix: patch' }],
+  },
+  securityHotspots: {
+    keywordPattern: 'GHSA-|CVE-|CWE-',
+    topFiles: [{ path: 'src/app.ts', touches: 1 }],
+    matches: [{ hash: 'def5678', subject: 'fix(security): CVE-2024-1234', tier: 1 }],
+  },
+})
+
 describe('renderPrettyReport', () => {
   test('renders a stable report without throwing', () => {
     const report: AnalysisReport = {
-      schemaVersion: REPORT_SCHEMA_VERSION,
-      generatedAt: '2026-04-15T00:00:00.000Z',
-      repository: {
-        path: '/tmp/repo',
-        topLevel: '/tmp/repo',
-        head: 'deadbeef',
-      },
-      churn: { window: '1 year ago', topFiles: [{ path: 'src/app.ts', touches: 42 }] },
-      contributors: {
-        allTime: [{ name: 'Ada', commits: 10 }],
-        lastYear: [{ name: 'Ada', commits: 10 }],
-        lastSixMonths: [{ name: 'Ada', commits: 4 }],
-      },
-      bugHotspots: { pattern: 'fix|bug|broken', topFiles: [{ path: 'src/app.ts', touches: 3 }] },
-      activityByMonth: [
-        { month: '2026-01', commits: 2 },
-        { month: '2026-02', commits: 6 },
-        { month: '2026-03', commits: 4 },
-      ],
-      firefighting: {
-        window: '1 year ago',
-        keywordPattern: 'revert|hotfix|emergency|rollback',
-        matches: [{ hash: 'abc1234', subject: 'hotfix: patch' }],
-      },
-      securityHotspots: {
-        keywordPattern: 'GHSA-|CVE-|CWE-',
-        topFiles: [{ path: 'src/app.ts', touches: 1 }],
-        matches: [{ hash: 'def5678', subject: 'fix(security): CVE-2024-1234', tier: 1 }],
-      },
+      ...basePrettyFixture(),
       insights: [
         { id: 'churn_bug_overlap', level: 'warn', message: 'example overlap' },
         { id: 'squash_merge_caveat', level: 'info', message: 'example caveat' },
@@ -46,5 +70,42 @@ describe('renderPrettyReport', () => {
     assert.ok(out.includes('repolyze'))
     assert.ok(out.includes('src/app.ts'))
     assert.ok(out.includes('Activity by month'))
+  })
+
+  test('main section titles appear in canonical order (with insights)', () => {
+    const report: AnalysisReport = {
+      ...basePrettyFixture(),
+      insights: [
+        { id: 'churn_bug_overlap', level: 'warn', message: 'example overlap' },
+        { id: 'squash_merge_caveat', level: 'info', message: 'example caveat' },
+      ],
+    }
+    const out = renderPrettyReport(report)
+    assertPrettySectionMarkerOrder(out, [
+      'Activity by month ·',
+      'Contributors · non-merge commits',
+      'Churn · top paths · since',
+      'Bug-keyword hotspots · grep',
+      'Firefighting · oneline · since',
+      'Security-fix hotspots ·',
+      '── Insights',
+    ])
+  })
+
+  test('main section titles appear in canonical order (no insights block)', () => {
+    const report: AnalysisReport = {
+      ...basePrettyFixture(),
+      insights: [],
+    }
+    const out = renderPrettyReport(report)
+    assert.strictEqual(stripAnsi(out).includes('── Insights'), false)
+    assertPrettySectionMarkerOrder(out, [
+      'Activity by month ·',
+      'Contributors · non-merge commits',
+      'Churn · top paths · since',
+      'Bug-keyword hotspots · grep',
+      'Firefighting · oneline · since',
+      'Security-fix hotspots ·',
+    ])
   })
 })

--- a/src/render/pretty.ts
+++ b/src/render/pretty.ts
@@ -239,16 +239,6 @@ export function renderPrettyReport (report: AnalysisReport): string {
   lines.push(...renderContributionStrip(report.activityByMonth, color, width))
   lines.push('')
 
-  lines.push(horizontalRule(`Churn · top paths · since ${report.churn.window}`, width, color))
-  lines.push('')
-  lines.push(...rankedPathsTable(report.churn.topFiles, { color, width, highlightPaths: bugPaths, tone: 'churn' }))
-  lines.push('')
-
-  lines.push(horizontalRule(`Bug-keyword hotspots · grep ${report.bugHotspots.pattern}`, width, color))
-  lines.push('')
-  lines.push(...rankedPathsTable(report.bugHotspots.topFiles, { color, width, highlightPaths: churnPaths, tone: 'bugs' }))
-  lines.push('')
-
   lines.push(horizontalRule('Contributors · non-merge commits', width, color))
   lines.push('')
   lines.push(paint('    Last year (or all-time if empty):', ansi.dim, color))
@@ -273,6 +263,16 @@ export function renderPrettyReport (report: AnalysisReport): string {
       rank6 += 1
     }
   }
+  lines.push('')
+
+  lines.push(horizontalRule(`Churn · top paths · since ${report.churn.window}`, width, color))
+  lines.push('')
+  lines.push(...rankedPathsTable(report.churn.topFiles, { color, width, highlightPaths: bugPaths, tone: 'churn' }))
+  lines.push('')
+
+  lines.push(horizontalRule(`Bug-keyword hotspots · grep ${report.bugHotspots.pattern}`, width, color))
+  lines.push('')
+  lines.push(...rankedPathsTable(report.bugHotspots.topFiles, { color, width, highlightPaths: churnPaths, tone: 'bugs' }))
   lines.push('')
 
   lines.push(horizontalRule(`Firefighting · oneline · since ${report.firefighting.window} · ${report.firefighting.keywordPattern}`, width, color))


### PR DESCRIPTION
## Description

- Move the **Contributors** block immediately after **Activity by month** in `renderPrettyReport`.
- Add regression tests that assert canonical section title order (with and without an Insights block), comparing markers on ANSI-stripped output for stable matching.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

N/A — display ordering and test coverage only.

## Motivation and Context

Groups human-oriented output (contributors) next to the activity timeline and prevents accidental section reorder regressions.

## How Has This Been Tested?

Ran `npm test` locally. New unit tests cover section marker order with insights present and absent.

## Screenshots (if appropriate):

N/A

## Checklist:

- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun

Made with [Cursor](https://cursor.com)