### PR TITLE
refactor(cli): use util.parseArgs for argv parsing

### DIFF
--- a/src/cli/parseArgs.ts
+++ b/src/cli/parseArgs.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import { parseArgs } from 'node:util'
 
 export interface ParsedCli {
   help: boolean
@@ -44,46 +45,34 @@ export function dropIfEntryScriptPath (argv: string[], entryFilePath: string): s
 }
 
 export function parseCliArgv (argv: string[]): ParsedCli {
-  const positionals: string[] = []
-  let help = false
-  let verbose = false
-  let json = false
-
-  for (let i = 0; i < argv.length; i++) {
-    const a = argv[i]
-    if (a === undefined) continue
-
-    if (a === '--') {
-      for (const p of argv.slice(i + 1)) positionals.push(p)
-      break
-    }
-
-    if (a === '--help' || a === '-h') {
-      help = true
-      continue
-    }
-    if (a === '--verbose' || a === '-v') {
-      verbose = true
-      continue
-    }
-    if (a === '--json') {
-      json = true
-      continue
-    }
-
-    if (a.startsWith('-')) {
-      throw new CliParseError(`Unknown option: ${a}`)
-    }
-
-    positionals.push(a)
+  let parsed
+  try {
+    parsed = parseArgs({
+      args: argv,
+      strict: true,
+      allowPositionals: true,
+      options: {
+        help: { type: 'boolean', short: 'h' },
+        verbose: { type: 'boolean', short: 'v' },
+        json: { type: 'boolean' },
+      },
+    })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new CliParseError(msg)
   }
 
-  const repositoryPath = positionals[0] ?? '.'
+  const { values, positionals } = parsed
   if (positionals.length > 1) {
     throw new CliParseError('Too many positional arguments (expected 0 or 1 repository paths).')
   }
 
-  return { help, verbose, json, repositoryPath }
+  return {
+    help: values.help === true,
+    verbose: values.verbose === true,
+    json: values.json === true,
+    repositoryPath: positionals[0] ?? '.',
+  }
 }
 
 export const HELP_TEXT = `repolyze — scan a repository’s git history for maintainership and risk signals.

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -1,4 +1,5 @@
 import { execFile as execFileCallback } from 'node:child_process'
+import process from 'node:process'
 import { promisify } from 'node:util'
 
 const execFile = promisify(execFileCallback)


### PR DESCRIPTION
Replace the hand-rolled argv loop with parseArgs from node:util while preserving strict mode, unknown-option errors wrapped in CliParseError, and the single-repository positional rule.

Import process explicitly in git.ts for consistency with the CLI entry.

Made-with: Cursor

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation (if required).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I added a picture of a cute animal cause it's fun
