### PR TITLE
fix: disable trustPolicyIgnoreAfter in pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,7 +16,7 @@ trustPolicy: no-downgrade
 
 # Ignore the check for packages published more than 30 days ago (pnpm 10.27+)
 # Useful for older packages that pre-date provenance support
-trustPolicyIgnoreAfter: 43200
+# trustPolicyIgnoreAfter: 43200
 
 allowBuilds:
   esbuild: true


### PR DESCRIPTION
Comments out `trustPolicyIgnoreAfter: 43200` in `pnpm-workspace.yaml`.

When this value equals `minimumReleaseAge`, every installable package (older than 30d) automatically bypasses the `trustPolicy: no-downgrade` check, making the trust policy a no-op. Disabling the setting restores `no-downgrade` enforcement across all installed versions.

See discussion in https://github.com/lirantal/cfkit/pull/53 for context.